### PR TITLE
Add iOS stub implementation for Flutter compatibility

### DIFF
--- a/ios/Classes/NearpayPlugin.h
+++ b/ios/Classes/NearpayPlugin.h
@@ -1,0 +1,4 @@
+#import <Flutter/Flutter.h>
+
+@interface NearpayPlugin : NSObject<FlutterPlugin>
+@end

--- a/ios/Classes/NearpayPlugin.m
+++ b/ios/Classes/NearpayPlugin.m
@@ -1,0 +1,16 @@
+#import "NearpayPlugin.h"
+
+@implementation NearpayPlugin
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {
+  // Stub implementation - NearPay is Android-only
+  // This is here to satisfy Flutter's plugin registration
+  // No actual functionality is needed on iOS
+}
+
+- (void)handleMethodCall:(FlutterMethodCall*)call result:(FlutterResult)result {
+  // Return not implemented for all method calls
+  result(FlutterMethodNotImplemented);
+}
+
+@end

--- a/ios/nearpay_flutter_sdk.podspec
+++ b/ios/nearpay_flutter_sdk.podspec
@@ -1,0 +1,23 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# This is a stub podspec for iOS builds - nearpay_flutter_sdk is Android-only
+#
+Pod::Spec.new do |s|
+  s.name             = 'nearpay_flutter_sdk'
+  s.version          = '0.0.1'
+  s.summary          = 'NearPay Flutter SDK - Android only (stub for iOS)'
+  s.description      = <<-DESC
+This is a stub podspec for iOS builds. NearPay Flutter SDK is Android-only.
+                       DESC
+  s.homepage         = 'https://github.com/nearpayio/nearpay-flutter-sdk'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'NearPay' => 'info@nearpay.io' }
+  s.source           = { :path => '.' }
+  s.source_files     = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '11.0'
+
+  # Flutter.framework does not contain a i386 slice.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'EXCLUDED_ARCHS[sdk=iphonesimulator*]' => 'i386' }
+  s.swift_version = '5.0'
+end


### PR DESCRIPTION
This commit adds a stub iOS implementation to allow the plugin to work in iOS builds without breaking compilation, while maintaining Android-only functionality.

Changes:
- Add nearpay_flutter_sdk.podspec for CocoaPods
- Add NearpayPlugin stub class that registers but does nothing
- All iOS method calls return FlutterMethodNotImplemented